### PR TITLE
fix(quotation): quote is not calculating cover and premium correctly when spin edits are clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,8 +323,8 @@
 											
 											<div class="col-50">
 												<div class="form-group">
-													<input type="number" id="premiumInput" name="insureValue" class="form-control insure-value" placeholder="Premium" min="500" maxlength="6" onkeyup="debouncedGetCover();">
-													<input type="number" id="coverInput" name="insureValue" class="form-control insure-value" placeholder="Cover" min="500" maxlength="9" onkeyup="debouncedGetPremium();">
+													<input type="number" id="premiumInput" name="insureValue" class="form-control insure-value" step="50" placeholder="Premium" min="500" maxlength="6" onchange="debouncedGetCover();" onkeyup="debouncedGetCover();">
+													<input type="number" id="coverInput" name="insureValue" class="form-control insure-value" step="50" placeholder="Cover" min="500" maxlength="9" onchange="debouncedGetPremium();" onkeyup="debouncedGetPremium();">
 													<sub class="text-warning error-message" id="prem-error"></sub>
 												</div>
 											</div>


### PR DESCRIPTION
### Issue {{OL-15}}
Closes #15 

### Completed
* Fixed issue where quotation form was not calculating values correctly when a user used the spin edits to change the amounts in the Premium or Cover inputs.
* Added a step of 50 to the spin edit increment and decrement to make the UX more sensible.

### Screenshots
* **Quotation form now calculates values as expected.**

https://user-images.githubusercontent.com/30522249/159069552-7f99802b-43d6-4d88-b39e-fa13b0bb49de.mp4

* **Using the spin edits still respects the minimum and maximum limits of the quotation logic.**

https://user-images.githubusercontent.com/30522249/159069524-d5b66ec8-6919-4e28-b57b-117020d4d9f1.mp4

### Verification Process
* Pull down the branch.
* Open index.html in a browser.
* Go to the website's Request a Quote section.
* Verify that using the spin edits generates a quote correctly.